### PR TITLE
Update slack-express to version 5.0.0 🚀

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "node-env-file": "^0.1.8",
     "node-uuid": "^1.4.7",
     "request": "^2.67.0",
-    "slack-express": "^4.0.0"
+    "slack-express": "^5.0.0"
   }
 }


### PR DESCRIPTION
Hello :wave:

:rocket::rocket::rocket:

[slack-express](https://www.npmjs.com/package/slack-express) just published its new version 5.0.0, which **is not covered by your current version range**.

If this pull request passes your tests you can publish your software with the latest version of slack-express – otherwise use this branch to work on adaptions and fixes.


Happy fixing and merging :palm_tree:

---
The new version differs by 6 commits .

- [`66265b2`](https://github.com/smallwins/slack-express/commit/66265b21dfed54640f9f699917d1cc0aa09707e2) `5.0.0`
- [`b6ed81e`](https://github.com/smallwins/slack-express/commit/b6ed81e3da3cb90f8595655e7db7ad2809cbe515) `Merge branch 'master' of github.com:smallwins/slack-express`
- [`b21b1c4`](https://github.com/smallwins/slack-express/commit/b21b1c4598885e418daa83f1c277bf63b02f23a6) `4.0.0`
- [`4660fce`](https://github.com/smallwins/slack-express/commit/4660fce9aa5c6bed7fd473ead733e7c3dd36d199) `Removes dependency on environment variables.`
- [`9e771ef`](https://github.com/smallwins/slack-express/commit/9e771ef1e1ddc8dcd18c6fd062b5e2711ff60f9f) `4.0.1`
- [`4edd859`](https://github.com/smallwins/slack-express/commit/4edd859e03282f564434fb2ab36d1c9628c803fc) `better error msg for missing env vars`

See the [full diff](https://github.com/smallwins/slack-express/compare/32cc75c8c12957e5279bcc91f6ef91e81e5fd41f...66265b21dfed54640f9f699917d1cc0aa09707e2).