### PR TITLE
slack-express@5.3.0 breaks build 🚨

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,6 @@
     "node-env-file": "^0.1.8",
     "node-uuid": "^1.4.7",
     "request": "^2.67.0",
-    "slack-express": "^5.2.0"
+    "slack-express": "^5.3.0"
   }
 }


### PR DESCRIPTION
Hello :wave:

:rotating_light::rotating_light::rotating_light:

[slack-express](https://www.npmjs.com/package/slack-express) just published its new version 5.3.0, which **is covered by your current version range**. After updating it in your project **the build went from success to failure**.

This means **your software is now malfunctioning**, because of this update. Use this branch to work on adaptions and fixes.


Happy fixing and merging :palm_tree:

---
The new version differs by 2 commits .

- [`1af5315`](https://github.com/smallwins/slack-express/commit/1af53150c6465d8277df80a7d083e840b58c7e30) `5.3.0`
- [`a91acae`](https://github.com/smallwins/slack-express/commit/a91acae7a56b8cb079377ccd2261c1b53ac1f396) `removing …from response`

See the [full diff](https://github.com/smallwins/slack-express/compare/67d7d92b811c0d3930a54e1b03d4731766d0fef1...1af53150c6465d8277df80a7d083e840b58c7e30).